### PR TITLE
Refactor assert that

### DIFF
--- a/assert/assert.go
+++ b/assert/assert.go
@@ -8,8 +8,9 @@ type defaultAssert struct {
 	t *testing.T
 }
 
-// NewFatal returns an assert interface implementation which does not allow code
-// execution to continue when tests fail.
+// NewFatal returns an assert function, which is used to make assertions.
+// If any assertion fails using this function, code execution is immediately stopped
+// and the test is marked as having failed.
 func NewFatal(t *testing.T) func(got interface{}) comparator {
 	return func(got interface{}) comparator {
 		return fatalComparator{
@@ -19,8 +20,9 @@ func NewFatal(t *testing.T) func(got interface{}) comparator {
 	}
 }
 
-// New returns an assert interface implementation which allows code execution
-// to continue when tests fail.
+// New returns an assert function, which is used to make assertions.
+// If any assertion fails using this function, code execution is allowed to continue,
+// but the test is marked as having failed.
 func New(t *testing.T) func(got interface{}) comparator {
 	return func(got interface{}) comparator {
 		return defaultComparator{

--- a/assert/assert.go
+++ b/assert/assert.go
@@ -4,47 +4,28 @@ import (
 	"testing"
 )
 
-type assert interface {
-	// That prepares the observed value, the 'got' argument', for comparison by
-	// returning a comparator interface, with which the observed value can be
-	// compared.
-	That(got interface{}) comparator
-}
-
 type defaultAssert struct {
 	t *testing.T
 }
 
 // NewFatal returns an assert interface implementation which does not allow code
 // execution to continue when tests fail.
-func NewFatal(t *testing.T) assert {
-	return fatalAssert{
-		t: t,
+func NewFatal(t *testing.T) func(got interface{}) comparator {
+	return func(got interface{}) comparator {
+		return fatalComparator{
+			t:   t,
+			got: got,
+		}
 	}
 }
 
 // New returns an assert interface implementation which allows code execution
 // to continue when tests fail.
-func New(t *testing.T) assert {
-	return defaultAssert{
-		t: t,
-	}
-}
-
-func (c defaultAssert) That(got interface{}) comparator {
-	return defaultComparator{
-		t:   c.t,
-		got: got,
-	}
-}
-
-type fatalAssert struct {
-	t *testing.T
-}
-
-func (f fatalAssert) That(got interface{}) comparator {
-	return fatalComparator{
-		t:   f.t,
-		got: got,
+func New(t *testing.T) func(got interface{}) comparator {
+	return func(got interface{}) comparator {
+		return defaultComparator{
+			t:   t,
+			got: got,
+		}
 	}
 }

--- a/assert/comparator.go
+++ b/assert/comparator.go
@@ -26,15 +26,23 @@ type comparator interface {
 	// same, and if their elements are equal ignoring order.
 	EqualsElementsInIgnoringOrder(want interface{})
 
-	// IsEmpty checks whether the observed value is empty. If not, the function
+	// IsEmpty checks whether the observed value is empty. If not empty, the function
 	// under test is marked as having failed.
+	// Arrays, channels, maps and slices are considered empty if they're nil or has zero
+	// length.
+	// Pointers are considered empty if the dereferenced values are nil.
+	// For all other types, the zero value is considered empty.
 	IsEmpty()
 
-	// IsNil checks whether the observed value is nil. If not, the function
+	// IsNil checks whether the observed value is nil. If not nil, the function
 	// under test is marked as having failed.
 	IsNil()
 
-	// IsNotNil checks whether the observed value is not nil. If not, the function
+	// IsNotEmpty checks whether the observed value isn't empty. If empty, the function
+	// under test is marked as having failed.
+	IsNotEmpty()
+
+	// IsNotNil checks whether the observed value is not nil. If nil, the function
 	// under test is marked as having failed.
 	IsNotNil()
 }
@@ -94,6 +102,12 @@ func isNil(got interface{}, errorf func(string, ...interface{})) {
 		}
 	}
 	errorf("expected nil value, found %+v", got)
+}
+
+func isNotEmpty(got interface{}, errorf func(string, ...interface{})) {
+	if isEmpty(got) {
+		errorf("expected %#v not to be empty, found empty", got)
+	}
 }
 
 func isNotNil(got interface{}, errorf func(string, ...interface{})) {
@@ -167,7 +181,7 @@ func isEmpty(obj interface{}) bool {
 		return isEmpty(objValue.Elem().Interface())
 	default:
 		objTypeZeroValue := reflect.Zero(objValue.Type())
-		return reflect.DeepEqual(obj, objTypeZeroValue)
+		return reflect.DeepEqual(obj, objTypeZeroValue.Interface())
 	}
 }
 

--- a/assert/default_comparator.go
+++ b/assert/default_comparator.go
@@ -25,6 +25,10 @@ func (d defaultComparator) IsNil() {
 	isNil(d.got, d.t.Errorf)
 }
 
+func (d defaultComparator) IsNotEmpty() {
+	isNotEmpty(d.got, d.t.Errorf)
+}
+
 func (d defaultComparator) IsNotNil() {
 	isNotNil(d.got, d.t.Errorf)
 }

--- a/assert/default_comparator_test.go
+++ b/assert/default_comparator_test.go
@@ -114,12 +114,13 @@ func TestEquals(t *testing.T) {
 			// when
 			instanceT := &testing.T{}
 			assert := New(instanceT)
-			assert.That(tc.got).Equals(tc.want)
+			assert(tc.got).Equals(tc.want)
 
 			// then
-			if tc.wantTFailed != instanceT.Failed() {
-				subT.Errorf("expected %#v (want) equals %#v (got) to be %v, found %v", tc.want, tc.got, tc.wantTFailed, instanceT.Failed())
+			if tc.wantTFailed == instanceT.Failed() {
+				return
 			}
+			subT.Errorf("expected assert(%#v).Equals(%#v) to be %v, found %v", tc.got, tc.want, !tc.wantTFailed, !instanceT.Failed())
 		})
 	}
 
@@ -204,7 +205,7 @@ func TestIsNil(t *testing.T) {
 		t.Run(name, func(subT *testing.T) {
 			// when
 			assert := New(tc.givenT)
-			assert.That(tc.got).IsNil()
+			assert(tc.got).IsNil()
 
 			gotTFailed := tc.givenT.Failed()
 
@@ -212,7 +213,7 @@ func TestIsNil(t *testing.T) {
 			if gotTFailed == tc.wantTFailed {
 				return
 			}
-			subT.Errorf("expected IsNil( %#v ) to be %v, found %v", tc.got, tc.wantTFailed, gotTFailed)
+			subT.Errorf("expected assert(%#v).IsNil() to be %v, found %v", tc.got, !tc.wantTFailed, !gotTFailed)
 		})
 	}
 }
@@ -296,7 +297,7 @@ func TestIsNotNil(t *testing.T) {
 		t.Run(name, func(subT *testing.T) {
 			// when
 			assert := New(tc.givenT)
-			assert.That(tc.got).IsNotNil()
+			assert(tc.got).IsNotNil()
 
 			gotTFailed := tc.givenT.Failed()
 
@@ -304,7 +305,7 @@ func TestIsNotNil(t *testing.T) {
 			if gotTFailed == tc.wantTFailed {
 				return
 			}
-			subT.Errorf("expected IsNotNil( %#v ) to be %v, found %v", tc.got, tc.wantTFailed, gotTFailed)
+			subT.Errorf("expected assert(%#v).IsNotNil() to be %v, found %v", tc.got, !tc.wantTFailed, !gotTFailed)
 		})
 	}
 }
@@ -492,7 +493,7 @@ func TestEqualsElementsInIgnoringOrder(t *testing.T) {
 		t.Run(name, func(subT *testing.T) {
 			// when
 			assert := New(tc.givenT)
-			assert.That(tc.got).EqualsElementsInIgnoringOrder(tc.want)
+			assert(tc.got).EqualsElementsInIgnoringOrder(tc.want)
 
 			gotTFailed := tc.givenT.Failed()
 
@@ -500,7 +501,7 @@ func TestEqualsElementsInIgnoringOrder(t *testing.T) {
 			if gotTFailed == tc.wantTFailed {
 				return
 			}
-			subT.Errorf("expected %#v (want) equalsElementsInIgnoringOrder %#v (got) to be %v, found %v", tc.want, tc.got, tc.wantTFailed, gotTFailed)
+			subT.Errorf("expected assert(%#v).EqualsElementsInIgnoringOrder(%#v) to be %v, found %v", tc.got, tc.want, !tc.wantTFailed, !gotTFailed)
 		})
 	}
 }

--- a/assert/default_comparator_test.go
+++ b/assert/default_comparator_test.go
@@ -66,44 +66,44 @@ var (
 func TestEquals(t *testing.T) {
 	// given
 	testCases := map[string]struct {
-		got         interface{}
-		want        interface{}
-		wantTFailed bool
+		got              interface{}
+		want             interface{}
+		wantAssertPassed bool
 	}{
 		"should pass for identical nil args": {
-			got:         nil,
-			want:        nil,
-			wantTFailed: false,
+			got:              nil,
+			want:             nil,
+			wantAssertPassed: true,
 		},
 		"should pass for equal comparable non-nil args": {
-			got:         nonZero["int"],
-			want:        nonZero["int"],
-			wantTFailed: false,
+			got:              nonZero["int"],
+			want:             nonZero["int"],
+			wantAssertPassed: true,
 		},
 		"should fail when want non-nil, but get nil": {
-			got:         nil,
-			want:        nonZero["int"],
-			wantTFailed: true,
+			got:              nil,
+			want:             nonZero["int"],
+			wantAssertPassed: false,
 		},
 		"should fail when want nil, but get comparable non-nil": {
-			got:         nonZero["struct"],
-			want:        nil,
-			wantTFailed: true,
+			got:              nonZero["struct"],
+			want:             nil,
+			wantAssertPassed: false,
 		},
 		"should fail when want comparable non-nil, but get non-comparable func": {
-			got:         nonZero["func"],
-			want:        nonZero["int"],
-			wantTFailed: true,
+			got:              nonZero["func"],
+			want:             nonZero["int"],
+			wantAssertPassed: false,
 		},
 		"should fail when want non-comparable func, but get comparable non-nil": {
-			got:         nonZero["string"],
-			want:        func() {},
-			wantTFailed: true,
+			got:              nonZero["string"],
+			want:             func() {},
+			wantAssertPassed: false,
 		},
 		"should fail for unequal comparable non-nil args": {
-			got:         nonZero["int"],
-			want:        nonZero["string"],
-			wantTFailed: true,
+			got:              nonZero["int"],
+			want:             nonZero["string"],
+			wantAssertPassed: false,
 		},
 	}
 
@@ -111,379 +111,197 @@ func TestEquals(t *testing.T) {
 	for name, tc := range testCases {
 		tc := tc
 		t.Run(name, func(subT *testing.T) {
+			// given
+			givenT := &testing.T{}
+			assert := New(givenT)
+
 			// when
-			instanceT := &testing.T{}
-			assert := New(instanceT)
 			assert(tc.got).Equals(tc.want)
 
 			// then
-			if tc.wantTFailed == instanceT.Failed() {
+			gotAssertPassed := !givenT.Failed()
+			if gotAssertPassed == tc.wantAssertPassed {
 				return
 			}
-			subT.Errorf("expected assert(%#v).Equals(%#v) to be %v, found %v", tc.got, tc.want, !tc.wantTFailed, !instanceT.Failed())
-		})
-	}
-
-}
-
-func TestIsNil(t *testing.T) {
-	testCases := map[string]struct {
-		got         interface{}
-		givenT      *testing.T
-		wantTFailed bool
-	}{
-		"should fail when get non-nilable": {
-			got:         nonZero["byte"],
-			givenT:      &testing.T{},
-			wantTFailed: true,
-		},
-		"should fail when get non-nil chan": {
-			got:         nonZero["chan"],
-			givenT:      &testing.T{},
-			wantTFailed: true,
-		},
-		"should pass when get nil chan": {
-			got:         zero["chan"],
-			givenT:      &testing.T{},
-			wantTFailed: false,
-		},
-		"should fail when get non-nil func": {
-			got:         nonZero["func"],
-			givenT:      &testing.T{},
-			wantTFailed: true,
-		},
-		"should pass when get nil func": {
-			got:         zero["func"],
-			givenT:      &testing.T{},
-			wantTFailed: false,
-		},
-		"should fail when get non-nil map": {
-			got:         nonZero["map"],
-			givenT:      &testing.T{},
-			wantTFailed: true,
-		},
-		"should pass when get nil map": {
-			got:         zero["map"],
-			givenT:      &testing.T{},
-			wantTFailed: false,
-		},
-		"should fail when get non-nil interface": {
-			got:         nonZero["interface"],
-			givenT:      &testing.T{},
-			wantTFailed: true,
-		},
-		"should pass when get nil interface": {
-			got:         zero["interface"],
-			givenT:      &testing.T{},
-			wantTFailed: false,
-		},
-		"should fail when get non-nil pointer": {
-			got:         nonZero["ptr"],
-			givenT:      &testing.T{},
-			wantTFailed: true,
-		},
-		"should pass when get nil pointer": {
-			got:         zero["ptr"],
-			givenT:      &testing.T{},
-			wantTFailed: false,
-		},
-		"should fail when get non-nil slice": {
-			got:         nonZero["slice"],
-			givenT:      &testing.T{},
-			wantTFailed: true,
-		},
-		"should pass when get nil slice": {
-			got:         zero["slice"],
-			givenT:      &testing.T{},
-			wantTFailed: false,
-		},
-	}
-
-	t.Parallel()
-	for name, tc := range testCases {
-		tc := tc
-		t.Run(name, func(subT *testing.T) {
-			// when
-			assert := New(tc.givenT)
-			assert(tc.got).IsNil()
-
-			gotTFailed := tc.givenT.Failed()
-
-			// then
-			if gotTFailed == tc.wantTFailed {
-				return
-			}
-			subT.Errorf("expected assert(%#v).IsNil() to be %v, found %v", tc.got, !tc.wantTFailed, !gotTFailed)
-		})
-	}
-}
-
-func TestIsNotNil(t *testing.T) {
-	testCases := map[string]struct {
-		got         interface{}
-		givenT      *testing.T
-		wantTFailed bool
-	}{
-		"should pass when get non-nilable": {
-			got:         nonZero["int"],
-			givenT:      &testing.T{},
-			wantTFailed: false,
-		},
-		"should pass when get non-nil chan": {
-			got:         nonZero["chan"],
-			givenT:      &testing.T{},
-			wantTFailed: false,
-		},
-		"should fail when get nil chan": {
-			got:         zero["chan"],
-			givenT:      &testing.T{},
-			wantTFailed: true,
-		},
-		"should pass when get non-nil func": {
-			got:         nonZero["func"],
-			givenT:      &testing.T{},
-			wantTFailed: false,
-		},
-		"should fail when get nil func": {
-			got:         zero["func"],
-			givenT:      &testing.T{},
-			wantTFailed: true,
-		},
-		"should pass when get non-nil map": {
-			got:         nonZero["map"],
-			givenT:      &testing.T{},
-			wantTFailed: false,
-		},
-		"should fail when get nil map": {
-			got:         zero["map"],
-			givenT:      &testing.T{},
-			wantTFailed: true,
-		},
-		"should pass when get non-nil interface": {
-			got:         nonZero["interface"],
-			givenT:      &testing.T{},
-			wantTFailed: false,
-		},
-		"should fail when get nil interface": {
-			got:         zero["interface"],
-			givenT:      &testing.T{},
-			wantTFailed: true,
-		},
-		"should pass when get non-nil pointer": {
-			got:         nonZero["ptr"],
-			givenT:      &testing.T{},
-			wantTFailed: false,
-		},
-		"should fail when get nil pointer": {
-			got:         zero["ptr"],
-			givenT:      &testing.T{},
-			wantTFailed: true,
-		},
-		"should pass when get non-nil slice": {
-			got:         nonZero["slice"],
-			givenT:      &testing.T{},
-			wantTFailed: false,
-		},
-		"should fail when get nil slice": {
-			got:         zero["slice"],
-			givenT:      &testing.T{},
-			wantTFailed: true,
-		},
-	}
-
-	t.Parallel()
-	for name, tc := range testCases {
-		tc := tc
-		t.Run(name, func(subT *testing.T) {
-			// when
-			assert := New(tc.givenT)
-			assert(tc.got).IsNotNil()
-
-			gotTFailed := tc.givenT.Failed()
-
-			// then
-			if gotTFailed == tc.wantTFailed {
-				return
-			}
-			subT.Errorf("expected assert(%#v).IsNotNil() to be %v, found %v", tc.got, !tc.wantTFailed, !gotTFailed)
+			subT.Errorf("expected assert(%#v).Equals(%#v) to be %v, found %v", tc.got, tc.want, tc.wantAssertPassed, gotAssertPassed)
 		})
 	}
 }
 
 func TestEqualsElementsInIgnoringOrder(t *testing.T) {
 	testCases := map[string]struct {
-		wantTFailed bool
-		want        interface{}
-		got         interface{}
-		givenT      *testing.T
+		wantAssertPassed bool
+		want             interface{}
+		got              interface{}
+		givenT           *testing.T
 	}{
 		"should fail when get bool": {
-			wantTFailed: true,
-			want:        nonZero["slice"],
-			got:         nonZero["bool"],
-			givenT:      &testing.T{},
+			wantAssertPassed: false,
+			want:             nonZero["slice"],
+			got:              nonZero["bool"],
+			givenT:           &testing.T{},
 		},
 		"should fail when get byte": {
-			wantTFailed: true,
-			want:        nonZero["slice"],
-			got:         nonZero["byte"],
-			givenT:      &testing.T{},
+			wantAssertPassed: false,
+			want:             nonZero["slice"],
+			got:              nonZero["byte"],
+			givenT:           &testing.T{},
 		},
 		"should fail when get chan": {
-			wantTFailed: true,
-			want:        nonZero["slice"],
-			got:         nonZero["chan"],
-			givenT:      &testing.T{},
+			wantAssertPassed: false,
+			want:             nonZero["slice"],
+			got:              nonZero["chan"],
+			givenT:           &testing.T{},
 		},
 		"should fail when get complex128": {
-			wantTFailed: true,
-			want:        nonZero["slice"],
-			got:         nonZero["complex128"],
-			givenT:      &testing.T{},
+			wantAssertPassed: false,
+			want:             nonZero["slice"],
+			got:              nonZero["complex128"],
+			givenT:           &testing.T{},
 		},
 		"should fail when get complex64": {
-			wantTFailed: true,
-			want:        nonZero["slice"],
-			got:         nonZero["complex64"],
-			givenT:      &testing.T{},
+			wantAssertPassed: false,
+			want:             nonZero["slice"],
+			got:              nonZero["complex64"],
+			givenT:           &testing.T{},
 		},
 		"should fail when get float32": {
-			wantTFailed: true,
-			want:        nonZero["slice"],
-			got:         nonZero["float32"],
-			givenT:      &testing.T{},
+			wantAssertPassed: false,
+			want:             nonZero["slice"],
+			got:              nonZero["float32"],
+			givenT:           &testing.T{},
 		},
 		"should fail when get float64": {
-			wantTFailed: true,
-			want:        nonZero["slice"],
-			got:         nonZero["float64"],
-			givenT:      &testing.T{},
+			wantAssertPassed: false,
+			want:             nonZero["slice"],
+			got:              nonZero["float64"],
+			givenT:           &testing.T{},
 		},
 		"should fail when get func": {
-			wantTFailed: true,
-			want:        nonZero["slice"],
-			got:         nonZero["func"],
-			givenT:      &testing.T{},
+			wantAssertPassed: false,
+			want:             nonZero["slice"],
+			got:              nonZero["func"],
+			givenT:           &testing.T{},
 		},
 		"should fail when get int": {
-			wantTFailed: true,
-			want:        nonZero["slice"],
-			got:         nonZero["int"],
-			givenT:      &testing.T{},
+			wantAssertPassed: false,
+			want:             nonZero["slice"],
+			got:              nonZero["int"],
+			givenT:           &testing.T{},
 		},
 		"should fail when get int8": {
-			wantTFailed: true,
-			want:        nonZero["slice"],
-			got:         nonZero["int8"],
-			givenT:      &testing.T{},
+			wantAssertPassed: false,
+			want:             nonZero["slice"],
+			got:              nonZero["int8"],
+			givenT:           &testing.T{},
 		},
 		"should fail when get int16": {
-			wantTFailed: true,
-			want:        nonZero["slice"],
-			got:         nonZero["int16"],
-			givenT:      &testing.T{},
+			wantAssertPassed: false,
+			want:             nonZero["slice"],
+			got:              nonZero["int16"],
+			givenT:           &testing.T{},
 		},
 		"should fail when get int32": {
-			wantTFailed: true,
-			want:        nonZero["slice"],
-			got:         nonZero["int32"],
-			givenT:      &testing.T{},
+			wantAssertPassed: false,
+			want:             nonZero["slice"],
+			got:              nonZero["int32"],
+			givenT:           &testing.T{},
 		},
 		"should fail when get int64": {
-			wantTFailed: true,
-			want:        nonZero["slice"],
-			got:         nonZero["int64"],
-			givenT:      &testing.T{},
+			wantAssertPassed: false,
+			want:             nonZero["slice"],
+			got:              nonZero["int64"],
+			givenT:           &testing.T{},
 		},
 		"should fail when get map": {
-			wantTFailed: true,
-			want:        nonZero["slice"],
-			got:         nonZero["map"],
-			givenT:      &testing.T{},
+			wantAssertPassed: false,
+			want:             nonZero["slice"],
+			got:              nonZero["map"],
+			givenT:           &testing.T{},
 		},
 		"should fail when get ptr": {
-			wantTFailed: true,
-			want:        nonZero["slice"],
-			got:         nonZero["ptr"],
-			givenT:      &testing.T{},
+			wantAssertPassed: false,
+			want:             nonZero["slice"],
+			got:              nonZero["ptr"],
+			givenT:           &testing.T{},
 		},
 		"should fail when get string": {
-			wantTFailed: true,
-			want:        nonZero["slice"],
-			got:         nonZero["string"],
-			givenT:      &testing.T{},
+			wantAssertPassed: false,
+			want:             nonZero["slice"],
+			got:              nonZero["string"],
+			givenT:           &testing.T{},
 		},
 		"should fail when get struct": {
-			wantTFailed: true,
-			want:        nonZero["slice"],
-			got:         nonZero["struct"],
-			givenT:      &testing.T{},
+			wantAssertPassed: false,
+			want:             nonZero["slice"],
+			got:              nonZero["struct"],
+			givenT:           &testing.T{},
 		},
 		"should pass when want slice and get the same set of elements in order": {
-			wantTFailed: false,
-			want:        []string{"a", "b", "c"},
-			got:         []string{"a", "b", "c"},
-			givenT:      &testing.T{},
+			wantAssertPassed: true,
+			want:             []string{"a", "b", "c"},
+			got:              []string{"a", "b", "c"},
+			givenT:           &testing.T{},
 		},
 		"should pass when want slice and get the same set of elements not in order": {
-			wantTFailed: false,
-			want:        []string{"a", "b", "c"},
-			got:         []string{"b", "c", "a"},
-			givenT:      &testing.T{},
+			wantAssertPassed: true,
+			want:             []string{"a", "b", "c"},
+			got:              []string{"b", "c", "a"},
+			givenT:           &testing.T{},
 		},
 		"should fail when want slice but get subset not in order": {
-			wantTFailed: true,
-			want:        []string{"a", "b", "c"},
-			got:         []string{"c", "a"},
-			givenT:      &testing.T{},
+			wantAssertPassed: false,
+			want:             []string{"a", "b", "c"},
+			got:              []string{"c", "a"},
+			givenT:           &testing.T{},
 		},
 		"should fail when want slice but get subset in order": {
-			wantTFailed: true,
-			want:        []string{"a", "b", "c"},
-			got:         []string{"b", "c"},
-			givenT:      &testing.T{},
+			wantAssertPassed: false,
+			want:             []string{"a", "b", "c"},
+			got:              []string{"b", "c"},
+			givenT:           &testing.T{},
 		},
 		"should pass when want array and get the same set of elements in order": {
-			wantTFailed: false,
-			want:        [3]string{"a", "b", "c"},
-			got:         [3]string{"a", "b", "c"},
-			givenT:      &testing.T{},
+			wantAssertPassed: true,
+			want:             [3]string{"a", "b", "c"},
+			got:              [3]string{"a", "b", "c"},
+			givenT:           &testing.T{},
 		},
 		"should pass when want array and get the same set of elements not in order": {
-			wantTFailed: false,
-			want:        [3]string{"a", "b", "c"},
-			got:         [3]string{"b", "c", "a"},
-			givenT:      &testing.T{},
+			wantAssertPassed: true,
+			want:             [3]string{"a", "b", "c"},
+			got:              [3]string{"b", "c", "a"},
+			givenT:           &testing.T{},
 		},
 		"should fail when want array but get subset not in order": {
-			wantTFailed: true,
-			want:        [3]string{"a", "b", "c"},
-			got:         [2]string{"c", "a"},
-			givenT:      &testing.T{},
+			wantAssertPassed: false,
+			want:             [3]string{"a", "b", "c"},
+			got:              [2]string{"c", "a"},
+			givenT:           &testing.T{},
 		},
 		"should fail when want array but get subset in order": {
-			wantTFailed: true,
-			want:        [3]string{"a", "b", "c"},
-			got:         [2]string{"b", "c"},
-			givenT:      &testing.T{},
+			wantAssertPassed: false,
+			want:             [3]string{"a", "b", "c"},
+			got:              [2]string{"b", "c"},
+			givenT:           &testing.T{},
 		},
 		"should pass when want array but get slice with same set of elements": {
-			wantTFailed: false,
-			want:        [3]string{"a", "b", "c"},
-			got:         []string{"a", "b", "c"},
-			givenT:      &testing.T{},
+			wantAssertPassed: true,
+			want:             [3]string{"a", "b", "c"},
+			got:              []string{"a", "b", "c"},
+			givenT:           &testing.T{},
 		},
 		"should pass when want slice but get array with same set of elements": {
-			wantTFailed: false,
-			want:        []string{"a", "b", "c"},
-			got:         [3]string{"a", "b", "c"},
-			givenT:      &testing.T{},
+			wantAssertPassed: true,
+			want:             []string{"a", "b", "c"},
+			got:              [3]string{"a", "b", "c"},
+			givenT:           &testing.T{},
 		},
 		"should pass when want and get empty slice": {
-			wantTFailed: false,
-			want:        []string{},
-			got:         []string{},
-			givenT:      &testing.T{},
+			wantAssertPassed: true,
+			want:             []string{},
+			got:              []string{},
+			givenT:           &testing.T{},
 		},
 	}
 
@@ -491,17 +309,574 @@ func TestEqualsElementsInIgnoringOrder(t *testing.T) {
 	for name, tc := range testCases {
 		tc := tc
 		t.Run(name, func(subT *testing.T) {
-			// when
+			// given
 			assert := New(tc.givenT)
+
+			// when
 			assert(tc.got).EqualsElementsInIgnoringOrder(tc.want)
 
-			gotTFailed := tc.givenT.Failed()
-
 			// then
-			if gotTFailed == tc.wantTFailed {
+			gotAssertPassed := !tc.givenT.Failed()
+			if gotAssertPassed == tc.wantAssertPassed {
 				return
 			}
-			subT.Errorf("expected assert(%#v).EqualsElementsInIgnoringOrder(%#v) to be %v, found %v", tc.got, tc.want, !tc.wantTFailed, !gotTFailed)
+			subT.Errorf("expected assert(%#v).EqualsElementsInIgnoringOrder(%#v) to be %v, found %v", tc.got, tc.want, tc.wantAssertPassed, gotAssertPassed)
+		})
+	}
+}
+
+func TestIsEmpty(t *testing.T) {
+	nonEmptyChan := make(chan int, 10)
+	nonEmptyChan <- 4
+	testcases := map[string]struct {
+		got              interface{}
+		givenT           *testing.T
+		wantAssertPassed bool
+	}{
+		"should pass when get empty array": {
+			got:              [0]int{},
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should fail when get non-empty array": {
+			got:              zero["array"],
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should pass when get zero-valued bool": {
+			got:              zero["bool"],
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should fail when get true bool": {
+			got:              true,
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should pass when get zero-valued byte": {
+			got:              zero["byte"],
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should fail when get non-zero-valued byte": {
+			got:              nonZero["byte"],
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should pass when get empty chan": {
+			got:              zero["chan"],
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should fail when get non-empty chan": {
+			got:              nonEmptyChan,
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should pass when get zero-valued complex64": {
+			got:              zero["complex64"],
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should fail when get non-zero-valued complex64": {
+			got:              nonZero["complex64"],
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should pass when get zero-valued complex128": {
+			got:              zero["complex128"],
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should fail when get non-zero-valued complex128": {
+			got:              nonZero["complex128"],
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should pass when get zero-valued float32": {
+			got:              zero["float32"],
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should fail when get non-zero-valued float32": {
+			got:              nonZero["float32"],
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should pass when get zero-valued func": {
+			got:              zero["func"],
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should fail when get non-zero-valued func": {
+			got:              nonZero["func"],
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should pass when get zero-valued int": {
+			got:              zero["int"],
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should fail when get non-zero-valued int": {
+			got:              nonZero["int"],
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should pass when get zero-valued interface": {
+			got:              zero["interface"],
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should fail when get non-zero-valued interface": {
+			got:              nonZero["interface"],
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should pass when get zero-valued map": {
+			got:              zero["map"],
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should fail when get non-zero-valued map": {
+			got:              nonZero["map"],
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should pass when get zero-valued ptr": {
+			got:              zero["ptr"],
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should fail when get non-zero-valued ptr": {
+			got:              nonZero["ptr"],
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should pass when get nil slice": {
+			got:              zero["slice"],
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should pass when get empty slice": {
+			got:              []int{},
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should fail when get non-zero-valued slice": {
+			got:              nonZero["slice"],
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should pass when get zero-valued string": {
+			got:              zero["string"],
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should fail when get non-zero-valued string": {
+			got:              nonZero["string"],
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should pass when get zero-valued struct": {
+			got:              zero["struct"],
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should fail when get non-zero-valued struct": {
+			got:              nonZero["struct"],
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+	}
+
+	t.Parallel()
+	for name, tc := range testcases {
+		tc := tc
+		t.Run(name, func(subT *testing.T) {
+			// given
+			assert := New(tc.givenT)
+
+			// when
+			assert(tc.got).IsEmpty()
+
+			// then
+			gotAssertPassed := !tc.givenT.Failed()
+			if gotAssertPassed == tc.wantAssertPassed {
+				return
+			}
+			subT.Errorf("expected assert(%#v).IsEmpty() to be %v, found %v", tc.got, tc.wantAssertPassed, gotAssertPassed)
+		})
+	}
+}
+
+func TestIsNil(t *testing.T) {
+	testCases := map[string]struct {
+		got              interface{}
+		givenT           *testing.T
+		wantAssertPassed bool
+	}{
+		"should fail when get non-nilable": {
+			got:              nonZero["byte"],
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should fail when get non-nil chan": {
+			got:              nonZero["chan"],
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should pass when get nil chan": {
+			got:              zero["chan"],
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should fail when get non-nil func": {
+			got:              nonZero["func"],
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should pass when get nil func": {
+			got:              zero["func"],
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should fail when get non-nil map": {
+			got:              nonZero["map"],
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should pass when get nil map": {
+			got:              zero["map"],
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should fail when get non-nil interface": {
+			got:              nonZero["interface"],
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should pass when get nil interface": {
+			got:              zero["interface"],
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should fail when get non-nil pointer": {
+			got:              nonZero["ptr"],
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should pass when get nil pointer": {
+			got:              zero["ptr"],
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should fail when get non-nil slice": {
+			got:              nonZero["slice"],
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should pass when get nil slice": {
+			got:              zero["slice"],
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+	}
+
+	t.Parallel()
+	for name, tc := range testCases {
+		tc := tc
+		t.Run(name, func(subT *testing.T) {
+			// given
+			assert := New(tc.givenT)
+
+			// when
+			assert(tc.got).IsNil()
+
+			// then
+			gotAssertPassed := !tc.givenT.Failed()
+			if gotAssertPassed == tc.wantAssertPassed {
+				return
+			}
+			subT.Errorf("expected assert(%#v).IsNil() to be %v, found %v", tc.got, tc.wantAssertPassed, gotAssertPassed)
+		})
+	}
+}
+
+func TestIsNotEmpty(t *testing.T) {
+	nonEmptyChan := make(chan int, 10)
+	nonEmptyChan <- 4
+	testcases := map[string]struct {
+		got              interface{}
+		givenT           *testing.T
+		wantAssertPassed bool
+	}{
+		"should fail when get empty array": {
+			got:              [0]int{},
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should pass when get non-empty array": {
+			got:              zero["array"],
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should fail when get zero-valued bool": {
+			got:              zero["bool"],
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should pass when get true bool": {
+			got:              true,
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should fail when get zero-valued byte": {
+			got:              zero["byte"],
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should pass when get non-zero-valued byte": {
+			got:              nonZero["byte"],
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should fail when get empty chan": {
+			got:              zero["chan"],
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should pass when get non-empty chan": {
+			got:              nonEmptyChan,
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should fail when get zero-valued complex64": {
+			got:              zero["complex64"],
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should pass when get non-zero-valued complex64": {
+			got:              nonZero["complex64"],
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should fail when get zero-valued complex128": {
+			got:              zero["complex128"],
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should pass when get non-zero-valued complex128": {
+			got:              nonZero["complex128"],
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should fail when get zero-valued float32": {
+			got:              zero["float32"],
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should pass when get non-zero-valued float32": {
+			got:              nonZero["float32"],
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should fail when get zero-valued func": {
+			got:              zero["func"],
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should pass when get non-zero-valued func": {
+			got:              nonZero["func"],
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should fail when get zero-valued int": {
+			got:              zero["int"],
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should pass when get non-zero-valued int": {
+			got:              nonZero["int"],
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should fail when get zero-valued interface": {
+			got:              zero["interface"],
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should pass when get non-zero-valued interface": {
+			got:              nonZero["interface"],
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should fail when get zero-valued map": {
+			got:              zero["map"],
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should pass when get non-zero-valued map": {
+			got:              nonZero["map"],
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should fail when get zero-valued ptr": {
+			got:              zero["ptr"],
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should pass when get non-zero-valued ptr": {
+			got:              nonZero["ptr"],
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should fail when get nil slice": {
+			got:              zero["slice"],
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should fail when get empty slice": {
+			got:              []int{},
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should pass when get non-zero-valued slice": {
+			got:              nonZero["slice"],
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should fail when get zero-valued string": {
+			got:              zero["string"],
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should pass when get non-zero-valued string": {
+			got:              nonZero["string"],
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should fail when get zero-valued struct": {
+			got:              zero["struct"],
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should pass when get non-zero-valued struct": {
+			got:              nonZero["struct"],
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+	}
+
+	t.Parallel()
+	for name, tc := range testcases {
+		tc := tc
+		t.Run(name, func(subT *testing.T) {
+			// given
+			assert := New(tc.givenT)
+
+			// when
+			assert(tc.got).IsNotEmpty()
+
+			// then
+			gotAssertPassed := !tc.givenT.Failed()
+			if gotAssertPassed == tc.wantAssertPassed {
+				return
+			}
+			subT.Errorf("expected assert(%#v).IsNotEmpty() to be %v, found %v", tc.got, tc.wantAssertPassed, gotAssertPassed)
+		})
+	}
+}
+
+func TestIsNotNil(t *testing.T) {
+	testCases := map[string]struct {
+		got              interface{}
+		givenT           *testing.T
+		wantAssertPassed bool
+	}{
+		"should pass when get non-nilable": {
+			got:              nonZero["int"],
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should pass when get non-nil chan": {
+			got:              nonZero["chan"],
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should fail when get nil chan": {
+			got:              zero["chan"],
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should pass when get non-nil func": {
+			got:              nonZero["func"],
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should fail when get nil func": {
+			got:              zero["func"],
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should pass when get non-nil map": {
+			got:              nonZero["map"],
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should fail when get nil map": {
+			got:              zero["map"],
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should pass when get non-nil interface": {
+			got:              nonZero["interface"],
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should fail when get nil interface": {
+			got:              zero["interface"],
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should pass when get non-nil pointer": {
+			got:              nonZero["ptr"],
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should fail when get nil pointer": {
+			got:              zero["ptr"],
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+		"should pass when get non-nil slice": {
+			got:              nonZero["slice"],
+			givenT:           &testing.T{},
+			wantAssertPassed: true,
+		},
+		"should fail when get nil slice": {
+			got:              zero["slice"],
+			givenT:           &testing.T{},
+			wantAssertPassed: false,
+		},
+	}
+
+	t.Parallel()
+	for name, tc := range testCases {
+		tc := tc
+		t.Run(name, func(subT *testing.T) {
+			// given
+			assert := New(tc.givenT)
+
+			// when
+			assert(tc.got).IsNotNil()
+
+			// then
+			gotAssertPassed := !tc.givenT.Failed()
+			if gotAssertPassed == tc.wantAssertPassed {
+				return
+			}
+			subT.Errorf("expected assert(%#v).IsNotNil() to be %v, found %v", tc.got, tc.wantAssertPassed, gotAssertPassed)
 		})
 	}
 }

--- a/assert/fatal_comparator.go
+++ b/assert/fatal_comparator.go
@@ -25,6 +25,10 @@ func (f fatalComparator) IsNil() {
 	isNil(f.got, f.t.Fatalf)
 }
 
+func (f fatalComparator) IsNotEmpty() {
+	isNotEmpty(f.got, f.t.Fatalf)
+}
+
 func (f fatalComparator) IsNotNil() {
 	isNotNil(f.got, f.t.Fatalf)
 }


### PR DESCRIPTION
Removes the assert.That(got) API and introduces a functional approach instead so the corresponding API becomes assert(got). Also improves commenting in general in addition to introducing an IsNotEmpty() check.